### PR TITLE
:bug: Fix export selected layer folder visibility issue

### DIFF
--- a/javascript/photopea-scripts.js
+++ b/javascript/photopea-scripts.js
@@ -58,7 +58,7 @@ function exportSelectedLayerOnly(format, layerSelector) {
             makeLayerVisible(layer);
         }
     }
-    app.activeDocument.saveToOE(format);
+    app.activeDocument.saveToOE(format || 'JPG');
 
     for (let i = 0; i < allLayers.length; i++) {
         const layer = allLayers[i];

--- a/javascript/photopea-scripts.js
+++ b/javascript/photopea-scripts.js
@@ -8,36 +8,61 @@
 // postMessageToPhotopea, then receive the data for the internal app.activeDocument.saveToOE("jpg");
 // below, then its done, and that solves the promise, but we end up with a dangling "done"
 // response from the script execution message. But hey, if it works... ^^'
-function exportSelectedLayerOnly() {
-    // Gets all layers recursively, including the ones inside folders.
-    function getAllArtLayers (document, layerCollection){
-        for (var i = 0; i < document.layers.length; i++){
-            var currentLayer = document.layers[i];
-            if (currentLayer.typename === "ArtLayer"){
-                layerCollection.push(currentLayer);
+function exportSelectedLayerOnly(format, layerSelector) {
+    const MAX_NESTING = 10;
+    function makeLayerVisible(layer) {
+        let currentLayer = layer;
+        let nest = 0;
+
+        while (currentLayer != app.activeDocument && nest < MAX_NESTING) {
+            nest++;
+            currentLayer.visible = true;
+            if (currentLayer.parent.typename != 'Document') {
+                currentLayer = currentLayer.parent;
             } else {
-                getAllArtLayers(currentLayer, layerCollection);
+                break;
             }
         }
-        return layerCollection;
+    }
+    // Gets all layers recursively, including the ones inside folders.
+    function getAllArtLayers(document) {
+        let allArtLayers = [];
+
+        for (let i = 0; i < document.layers.length; i++) {
+            const currentLayer = document.layers[i];
+            allArtLayers.push(currentLayer);
+            if (currentLayer.typename === "LayerSet") {
+                allArtLayers = allArtLayers.concat(getAllArtLayers(currentLayer));
+            }
+        }
+        return allArtLayers;
     }
 
-    var allLayers = []
-    allLayers = getAllArtLayers(app.activeDocument, allLayers);
+    const allLayers = getAllArtLayers(app.activeDocument);
     // Make all layers except the currently selected one invisible, and store
     // their initial state.
-    layerStates = []
-    for (var i = 0; i < allLayers.length; i++) {
-        layerStates.push(allLayers[i].visible)
-        allLayers[i].visible = allLayers[i] == app.activeDocument.activeLayer
+    const layerStates = [];
+    for (let i = 0; i < allLayers.length; i++) {
+        const layer = allLayers[i];
+        layerStates.push(layer.visible);
     }
+    // Hide all layers to begin with
+    for (let i = 0; i < allLayers.length; i++) {
+        const layer = allLayers[i];
+        layer.visible = false;
+    }
+    for (let i = 0; i < allLayers.length; i++) {
+        const layer = allLayers[i];
+        const selected = layerSelector ? layerSelector(layer) : layer.selected;
+        if (selected) {
+            makeLayerVisible(layer);
+        }
+    }
+    app.activeDocument.saveToOE(format);
 
-    // Output the image. We output JPG to make sure we don't end up with transparent backgrounds.
-    app.activeDocument.saveToOE("JPG");
-
-    // Restore layers
-    for (var i = 0; i < allLayers.length; i++) {
-        allLayers[i].visible = layerStates[i]
+    for (let i = 0; i < allLayers.length; i++) {
+        const layer = allLayers[i];
+        layer.visible = layerStates[i];
     }
 }
 


### PR DESCRIPTION
I found this bug when I am developing https://github.com/huchenlei/stable-diffusion-ps-pea. 

Steps to reproduce:
- Set photopea in following state with a folder invisible, and select the folder or anything inside the folder. 
![s1](https://github.com/yankooliveira/sd-webui-photopea-embed/assets/20929282/8ca4393f-785f-461c-a10d-2bbd95d1bf8d)
- Click send to inpaint mask. 
![s2](https://github.com/yankooliveira/sd-webui-photopea-embed/assets/20929282/b81e56d0-d3e3-4584-8888-ee6bc7edd0fd)
You can see that the mask is not properly captured.

For comparison, if you select a top level layer and perform the same action:
![s3](https://github.com/yankooliveira/sd-webui-photopea-embed/assets/20929282/c83ff342-15f0-46ee-b034-d9c9e6919683)
![s4](https://github.com/yankooliveira/sd-webui-photopea-embed/assets/20929282/64cad01b-7e4d-4910-af24-50c3751b4be9)

The issue is caused by original code does not account `LayerSet`'s visibility. For an ArtLayer to be visible on canvas, all it's parent's visibility all need to be true.

By default, add layer to add layer in current LayerSet if the activeLayer is a layerset or add a layer at the same level of the current active layer. So if we select the invisible folder layer, the new temp mask layer is added in the folder.

This PR port my implemenetation of exportSelectedLayerOnly from https://github.com/huchenlei/stable-diffusion-ps-pea, with extra feature of specifying export format and having a callback function to select which layer to export.